### PR TITLE
docs: 添加逸燧镜像站并更新部署配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,3 +154,23 @@ jobs:
         run: |
           echo "::error::推送到 yusheng929/karin-docs 仓库失败"
           echo "错误信息: ${{ steps.push-to-yusheng.outputs.error }}"
+
+      - name: Push to esyka114514/karin-docs
+        id: push-to-esyka
+        uses: peaceiris/actions-gh-pages@v3
+        continue-on-error: true
+        with:
+          personal_token: ${{ secrets.ESYKA }}
+          external_repository: esyka114514/karin-docs
+          publish_branch: gh-pages
+          publish_dir: docs/.vuepress/dist
+          force: true
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check esyka114514/karin-docs push status
+        if: steps.push-to-esyka.outcome == 'failure'
+        run: |
+          echo "::error::推送到 esyka114514/karin-docs 仓库失败"
+          echo "错误信息: ${{ steps.push-to-esyka.outputs.error }}"

--- a/docs/.vuepress/navbar.ts
+++ b/docs/.vuepress/navbar.ts
@@ -58,7 +58,7 @@ export const navbar = defineNavbarConfig([
       { text: 'Vercel 镜像(憨憨)', icon: 'mdi:web', link: 'https://karin.hanhanz.top' },
       { text: 'Deno 镜像', icon: 'mdi:web', link: 'https://karin.deno.dev' },
       { text: '私有 CDN 镜像(ikechan8370)', icon: 'mdi:web', link: 'https://karin.chaite.cloud' },
-      { text: 'EdgOne 镜像(逸燧)', icon: 'mdi:web', link: 'https://karin.esyka.top' },
+      { text: 'EdgeOne 镜像(逸燧)', icon: 'mdi:web', link: 'https://karin.esyka.top' },
     ],
   },
 ])

--- a/docs/.vuepress/navbar.ts
+++ b/docs/.vuepress/navbar.ts
@@ -58,6 +58,7 @@ export const navbar = defineNavbarConfig([
       { text: 'Vercel 镜像(憨憨)', icon: 'mdi:web', link: 'https://karin.hanhanz.top' },
       { text: 'Deno 镜像', icon: 'mdi:web', link: 'https://karin.deno.dev' },
       { text: '私有 CDN 镜像(ikechan8370)', icon: 'mdi:web', link: 'https://karin.chaite.cloud' },
+      { text: 'EdgOne 镜像(逸燧)', icon: 'mdi:web', link: 'https://karin.esyka.top' },
     ],
   },
 ])


### PR DESCRIPTION
添加 EdgOne 镜像链接到导航栏，同时更新 GitHub Actions 部署配置以支持推送到 esyka114514/karin-docs 仓库

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "EdgeOne 镜像(逸燧)" link to the documentation navbar for quicker access to an alternate mirror.

* **Chores**
  * Enhanced the deployment workflow to publish documentation to an additional docs site and added conditional error reporting if that publish step fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->